### PR TITLE
Feature/table service refactoring

### DIFF
--- a/src/main/java/com/moment/the/controller/release/TableController.java
+++ b/src/main/java/com/moment/the/controller/release/TableController.java
@@ -30,7 +30,7 @@ public class TableController {
     // localhost:8080/v1/uncomfortable/top30
     @GetMapping("/uncomfortable/top30")
     public ListResult<TableViewDto> top10(){
-        return responseService.getListResult(tableService.view());
+        return responseService.getListResult(tableService.top30View());
     }
 
     // localhost:8080/v1/uncomfortable

--- a/src/main/java/com/moment/the/dto/TableDto.java
+++ b/src/main/java/com/moment/the/dto/TableDto.java
@@ -16,9 +16,9 @@ public class TableDto {
     @NotBlank
     private String content;
 
-    public TableDomain toEntity(String content){
+    public TableDomain toEntity(){
         return TableDomain.builder()
-                .content(content)
+                .content(this.content)
                 .build();
     }
 }

--- a/src/main/java/com/moment/the/service/TableService.java
+++ b/src/main/java/com/moment/the/service/TableService.java
@@ -25,7 +25,7 @@ public class TableService {
     // 작성하기.
     @Transactional
     public TableDomain write(TableDto tableDto){
-        return tableRepository.save(tableDto.toEntity(tableDto.getContent()));
+        return tableRepository.save(tableDto.toEntity());
     }
 
     // Top 30 보여주기.

--- a/src/main/java/com/moment/the/service/TableService.java
+++ b/src/main/java/com/moment/the/service/TableService.java
@@ -29,7 +29,7 @@ public class TableService {
     }
 
     // Top 30 보여주기.
-    public List<TableViewDto> view() {
+    public List<TableViewDto> top30View() {
         return tableRepository.tableViewTopBy(PageRequest.of(0,30));
     }
 

--- a/src/test/java/com/moment/the/service/TableServiceTest.java
+++ b/src/test/java/com/moment/the/service/TableServiceTest.java
@@ -51,8 +51,8 @@ class TableServiceTest {
     }
 
     @Test
-    @DisplayName("TableService top30 보여주기(view) 검증")
-    void TableService_top30_view_검증(){
+    @DisplayName("TableService top30 보여주기(top30View) 검증")
+    void TableService_top30View_검증(){
         // Given
         AtomicInteger i = new AtomicInteger(1);
         List<TableDomain> TableDomains = Stream.generate(
@@ -69,16 +69,12 @@ class TableServiceTest {
         // Then
         assertEquals(viewTop30.size(), 30);
         AtomicInteger j = new AtomicInteger(40);
-        // TableService 의 view 로직이 올바르게 적용되면 j.get을 했을떄 값이 10이 나와야 한다.
-        // 저장된 Table - top30 = 40 - 30 = 10
+        // TableService 의 top30View 로직이 올바르게 적용되면 j.get을 했을떄 값이 10이 나와야 한다.
+        // 저장된Table - top30 = 40 - 30 = 10
         for(TableViewDto v : viewTop30 ) {
             assertEquals(v.getGoods(), j.getAndDecrement());
         }
         assertEquals(j.get(), 10);
-
-
-        //테스트가 끝났으므로 모든 DB는 삭제한다
-        tableRepo.deleteAll();
     }
 
     @Test

--- a/src/test/java/com/moment/the/service/TableServiceTest.java
+++ b/src/test/java/com/moment/the/service/TableServiceTest.java
@@ -64,7 +64,7 @@ class TableServiceTest {
 
         // When
         tableRepo.saveAll(TableDomains);
-        List<TableViewDto> viewTop30 = tableService.view();
+        List<TableViewDto> viewTop30 = tableService.top30View();
 
         // Then
         assertEquals(viewTop30.size(), 30);


### PR DESCRIPTION
TableService에대해 리펙토링을 진행했습니다.

### TODO
- view 메서드의 이름을 top30View로 이름을 변경했습니다.
- `TableDto`의 toEntity 메서드가`String content`를 인자로 받는것을 제거했습니다.
  > 이유: 이미 필드안에 `String content`가 선언되어 있는데 `toEntity` 를 호출하려면 자기자신의 `content`를 `getter` 메서드로 가져와야되는 불필요한 연산이 일어나기 떄문입니다.