### PR TITLE
Feature/answer service test

### DIFF
--- a/src/main/java/com/moment/the/service/AnswerService.java
+++ b/src/main/java/com/moment/the/service/AnswerService.java
@@ -21,6 +21,7 @@ public class AnswerService {
     final private AdminRepository adminRepo;
     final private AnswerRepository answerRepo;
     final private TableRepository tableRepo;
+    final private AdminServiceImpl adminServiceImpl;
 
     // 답변 작성하기
     public void save(AnswerDto answerDto, Long boardIdx) {
@@ -29,7 +30,7 @@ public class AnswerService {
         boolean existAnswer = tableDomain.getAnswerDomain() != null ? true : false;
         if(existAnswer) throw new AnswerAlreadyExistsException(); //이미 답변이 있으면 Exception
 
-        AdminDomain adminDomain = adminRepo.findByAdminId(getLoginAdminEmail());
+        AdminDomain adminDomain = adminRepo.findByAdminId(adminServiceImpl.GetUserEmail());
 
         // AnswerDomain 생성 및 Table 과의 연관관계 맻음
         answerDto.setAdminDomain(adminDomain);
@@ -44,7 +45,7 @@ public class AnswerService {
     public void update(AnswerDto answerDto, Long answerIdx) {
         AnswerDomain answerDomain = answerFindBy(answerIdx); // 해당하는 answer 찾기
         AdminDomain answerAdmin = answerDomain.getAdminDomain();
-        AdminDomain loginAdmin = adminRepo.findByAdminId(getLoginAdminEmail());
+        AdminDomain loginAdmin = adminRepo.findByAdminId(adminServiceImpl.GetUserEmail());
 
         answerOwnerCheck(answerAdmin, loginAdmin); // 자신이 작성한 답변인지 확인
 
@@ -73,7 +74,7 @@ public class AnswerService {
         AnswerDomain answerDomain = answerFindBy(answerIdx);
         AdminDomain answerAdmin = answerDomain.getAdminDomain();
 
-        AdminDomain loginAdmin = adminRepo.findByAdminId(getLoginAdminEmail());
+        AdminDomain loginAdmin = adminRepo.findByAdminId(adminServiceImpl.GetUserEmail());
         answerOwnerCheck(answerAdmin, loginAdmin); // 자신이 작성한 답변인지 확인
 
         // answer 삭제하기
@@ -93,18 +94,6 @@ public class AnswerService {
     // tableIdx 로 해당 table 찾기
     public TableDomain tableFindBy(Long tableId){
         return tableRepo.findById(tableId).orElseThrow(NoPostException::new);
-    }
-
-    // Current userEmail 을 가져오기.
-    public String getLoginAdminEmail() {
-        String userEmail;
-        AdminDomain principal = (AdminDomain) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        if(principal instanceof AdminDomain) {
-            userEmail = ((UserDetails)principal).getUsername();
-        } else {
-            userEmail = principal.toString();
-        }
-        return userEmail;
     }
 
     public void deleteAnswer(AnswerDomain answerDomain){

--- a/src/main/java/com/moment/the/service/AnswerService.java
+++ b/src/main/java/com/moment/the/service/AnswerService.java
@@ -21,7 +21,6 @@ public class AnswerService {
     final private AdminRepository adminRepo;
     final private AnswerRepository answerRepo;
     final private TableRepository tableRepo;
-    final private AdminServiceImpl adminServiceImpl;
 
     // 답변 작성하기
     public void save(AnswerDto answerDto, Long boardIdx) {
@@ -30,7 +29,7 @@ public class AnswerService {
         boolean existAnswer = tableDomain.getAnswerDomain() != null ? true : false;
         if(existAnswer) throw new AnswerAlreadyExistsException(); //이미 답변이 있으면 Exception
 
-        AdminDomain adminDomain = adminRepo.findByAdminId(adminServiceImpl.GetUserEmail());
+        AdminDomain adminDomain = adminRepo.findByAdminId(getLoginAdminEmail());
 
         // AnswerDomain 생성 및 Table 과의 연관관계 맻음
         answerDto.setAdminDomain(adminDomain);
@@ -45,7 +44,7 @@ public class AnswerService {
     public void update(AnswerDto answerDto, Long answerIdx) {
         AnswerDomain answerDomain = answerFindBy(answerIdx); // 해당하는 answer 찾기
         AdminDomain answerAdmin = answerDomain.getAdminDomain();
-        AdminDomain loginAdmin = adminRepo.findByAdminId(adminServiceImpl.GetUserEmail());
+        AdminDomain loginAdmin = adminRepo.findByAdminId(getLoginAdminEmail());
 
         answerOwnerCheck(answerAdmin, loginAdmin); // 자신이 작성한 답변인지 확인
 
@@ -74,7 +73,7 @@ public class AnswerService {
         AnswerDomain answerDomain = answerFindBy(answerIdx);
         AdminDomain answerAdmin = answerDomain.getAdminDomain();
 
-        AdminDomain loginAdmin = adminRepo.findByAdminId(adminServiceImpl.GetUserEmail());
+        AdminDomain loginAdmin = adminRepo.findByAdminId(getLoginAdminEmail());
         answerOwnerCheck(answerAdmin, loginAdmin); // 자신이 작성한 답변인지 확인
 
         // answer 삭제하기
@@ -94,6 +93,18 @@ public class AnswerService {
     // tableIdx 로 해당 table 찾기
     public TableDomain tableFindBy(Long tableId){
         return tableRepo.findById(tableId).orElseThrow(NoPostException::new);
+    }
+
+    // Current userEmail 을 가져오기.
+    public String getLoginAdminEmail() {
+        String userEmail;
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if(principal instanceof UserDetails) {
+            userEmail = ((UserDetails)principal).getUsername();
+        } else {
+            userEmail = principal.toString();
+        }
+        return userEmail;
     }
 
     public void deleteAnswer(AnswerDomain answerDomain){

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,7 +58,7 @@ spring:
   # Redis
   redis:
     image: redis:latest
-    host: localhost
+    host: redis
     port: 6379
 
   jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,7 +58,7 @@ spring:
   # Redis
   redis:
     image: redis:latest
-    host: redis
+    host: localhost
     port: 6379
 
   jwt:

--- a/src/test/java/com/moment/the/service/AnswerServiceTest.java
+++ b/src/test/java/com/moment/the/service/AnswerServiceTest.java
@@ -145,4 +145,25 @@ class AnswerServiceTest {
         assertEquals(answerResDto.getContent(), savedAnswer.getAnswerContent());
     }
 
+    @Test @DisplayName("답변 보기 (delete) 검증")
+    void delete_검증() throws Exception {
+        // Given
+        adminSignUp();
+        AdminDomain adminDomain = adminLogin();
+        TableDomain tableDomain = createTable();
+
+        // 답변 등록
+        String ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
+        AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
+        answerService.save(answerDto, tableDomain.getBoardIdx());
+        AnswerDomain savedAnswer = answerRepo.findTop1ByTableDomain_BoardIdx(tableDomain.getBoardIdx());
+
+        // When
+        answerService.delete(savedAnswer.getAnswerIdx());
+
+        // Then
+        // answer를 찾을 수 없으므로 exception 발생 (test 성공)
+        assertThrows(IllegalArgumentException.class,
+                () -> answerRepo.findById(savedAnswer.getAnswerIdx()).orElseThrow(() -> new IllegalArgumentException("AdminDomain을 찾을 수 없습니다.")));
+    }
 }

--- a/src/test/java/com/moment/the/service/AnswerServiceTest.java
+++ b/src/test/java/com/moment/the/service/AnswerServiceTest.java
@@ -9,23 +9,17 @@ import com.moment.the.dto.AnswerDto;
 import com.moment.the.dto.AnswerResDto;
 import com.moment.the.dto.TableDto;
 import com.moment.the.repository.AnswerRepository;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.test.context.support.WithAnonymousUser;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/moment/the/service/AnswerServiceTest.java
+++ b/src/test/java/com/moment/the/service/AnswerServiceTest.java
@@ -1,0 +1,62 @@
+package com.moment.the.service;
+
+import com.moment.the.config.security.MyUserDetailsService;
+import com.moment.the.domain.AdminDomain;
+import com.moment.the.domain.AnswerDomain;
+import com.moment.the.domain.TableDomain;
+import com.moment.the.dto.AdminDto;
+import com.moment.the.dto.AnswerDto;
+import com.moment.the.dto.TableDto;
+import com.moment.the.repository.AnswerRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@SpringBootTest
+class AnswerServiceTest {
+
+    @Autowired AdminService adminService;
+    @Autowired AnswerService answerService;
+    @Autowired AnswerRepository answerRepo;
+    @Autowired TableService tableService;
+    @Autowired MyUserDetailsService userDetailsService;
+
+    final String ADMIN_ID = "email@email";
+    final String PASSWORD = "password";
+    final String ROLE = "ADMIN";
+
+
+    @Test @DisplayName("답변 작성하기 (save) 검증")
+//    @WithMockUser(username = ADMIN_ID, password = PASSWORD, authorities = ROLE)
+    @WithAnonymousUser
+    void save_검증() throws Exception {
+        // Given
+        AdminDto adminDto = new AdminDto(ADMIN_ID, PASSWORD, ADMIN_ID);
+        adminService.signUp(adminDto);
+
+        String tableContent = "급식이 맛이 없어요 급식에 질을 높여주세요!";
+        TableDto tableDto = new TableDto(tableContent);
+        TableDomain tableDomain = tableService.write(tableDto);
+
+        String answerContent = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
+        AnswerDto answerDto = new AnswerDto(answerContent, null);
+
+        // When
+        answerService.save(answerDto, tableDomain.getBoardIdx());
+        AnswerDomain savedAnswer = answerRepo.findTop1ByTableDomain_BoardIdx(tableDomain.getBoardIdx());
+
+        // Then
+        assertEquals(savedAnswer.getTableDomain(), tableDomain);
+    }
+
+}

--- a/src/test/java/com/moment/the/service/AnswerServiceTest.java
+++ b/src/test/java/com/moment/the/service/AnswerServiceTest.java
@@ -8,16 +8,21 @@ import com.moment.the.dto.AdminDto;
 import com.moment.the.dto.AnswerDto;
 import com.moment.the.dto.TableDto;
 import com.moment.the.repository.AnswerRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -31,32 +36,58 @@ class AnswerServiceTest {
     @Autowired TableService tableService;
     @Autowired MyUserDetailsService userDetailsService;
 
+    // 유저정보
     final String ADMIN_ID = "email@email";
     final String PASSWORD = "password";
-    final String ROLE = "ADMIN";
+    final String ROLE = "ROLE_USER";
 
+    // test 편의를 위한 회원가입 매서드
+    void adminSignUp() throws Exception {
+        AdminDto adminDto = new AdminDto(ADMIN_ID, PASSWORD, "Admin");
+        adminService.signUp(adminDto);
+    }
+
+    //test 편의를 위한 로그인 매서드
+    AdminDomain adminLogin() throws Exception {
+        AdminDomain adminDomain = adminService.loginUser(ADMIN_ID, PASSWORD);
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                adminDomain.getAdminId(),
+                adminDomain.getAdminPwd(),
+                List.of(new SimpleGrantedAuthority(ROLE)));
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(token);
+
+        return adminDomain;
+    }
 
     @Test @DisplayName("답변 작성하기 (save) 검증")
-//    @WithMockUser(username = ADMIN_ID, password = PASSWORD, authorities = ROLE)
-    @WithAnonymousUser
     void save_검증() throws Exception {
         // Given
-        AdminDto adminDto = new AdminDto(ADMIN_ID, PASSWORD, ADMIN_ID);
-        adminService.signUp(adminDto);
+        //회원가입
+        adminSignUp();
 
-        String tableContent = "급식이 맛이 없어요 급식에 질을 높여주세요!";
-        TableDto tableDto = new TableDto(tableContent);
+        //로그인
+        AdminDomain adminDomain = adminLogin();
+
+        //Table 등록
+        String TABLE_CONTENT = "급식이 맛이 없어요 급식에 질을 높여주세요!";
+        TableDto tableDto = new TableDto(TABLE_CONTENT);
         TableDomain tableDomain = tableService.write(tableDto);
 
-        String answerContent = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
-        AnswerDto answerDto = new AnswerDto(answerContent, null);
+        //answer 등록
+        String ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
+        AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
 
         // When
         answerService.save(answerDto, tableDomain.getBoardIdx());
         AnswerDomain savedAnswer = answerRepo.findTop1ByTableDomain_BoardIdx(tableDomain.getBoardIdx());
 
         // Then
+        assertEquals(savedAnswer.getAnswerContent(), ANSWER_CONTENT);
         assertEquals(savedAnswer.getTableDomain(), tableDomain);
+        assertEquals(savedAnswer.getAdminDomain(), adminDomain);
     }
+
+
 
 }

--- a/src/test/java/com/moment/the/service/AnswerServiceTest.java
+++ b/src/test/java/com/moment/the/service/AnswerServiceTest.java
@@ -211,4 +211,42 @@ class AnswerServiceTest {
         assertThrows(IllegalArgumentException.class,
                 () -> answerRepo.findById(savedAnswer.getAnswerIdx()).orElseThrow(() -> new IllegalArgumentException("AdminDomain을 찾을 수 없습니다.")));
     }
+
+
+    @Test @DisplayName("답변 삭제 (delete) 다른사람의 답변을 삭제할 경우 AccessNotFoundException 검증")
+    void 다른사람의_답변을_삭제할경우_AccessNotFoundException_검증() throws Exception {
+        // Given
+        //회원가입
+        String ADMIN_A_ID = "adminAID";
+        String ADMIN_A_PW = "adminAPW";
+        String ADMIN_A_NAME = "adminA";
+
+        String ADMIN_B_ID = "adminBID";
+        String ADMIN_B_PW = "adminBPW";
+        String ADMIN_B_NAME = "adminB";
+
+        adminSignUp(ADMIN_A_ID, ADMIN_A_PW, ADMIN_A_NAME);
+        adminSignUp(ADMIN_B_ID, ADMIN_B_PW, ADMIN_B_NAME);
+
+        //로그인
+        AdminDomain adminADomain = adminLogin(ADMIN_A_ID, ADMIN_A_PW);
+
+        adminSignUp("adminB", "adminB_PW", "adminB");
+
+        TableDomain tableDomain = createTable();
+
+        // 답변 등록
+        String ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
+        AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
+        answerService.save(answerDto, tableDomain.getBoardIdx());
+        AnswerDomain savedAnswer = answerRepo.findTop1ByTableDomain_BoardIdx(tableDomain.getBoardIdx());
+
+        // When
+        AdminDomain adminB_Domain = adminLogin(ADMIN_B_ID, ADMIN_B_PW);
+
+        // Than
+        assertThrows(AccessNotFoundException.class
+                , () -> answerService.delete(savedAnswer.getAnswerIdx()));
+
+    }
 }


### PR DESCRIPTION
### TODO
- 핵심 비즈니스 로직에대해 test 완료(save, view, update, delete)
- `AnswerService`에 `getLoginAdminEmail()`  를 `AdminServiceImpl` 에 `GetUserEmail()` 와같은 로직으로 변경
  > AnswerService에 AdminServiceImpl에 의존성을 추가하지 않은이유는 AdminServiceImpl이 AnswerService를 의존하고 있어 순환참조 오류가 일어납니다. 나중에 리펙토링해야 할듯합니다.
- `save` 시 답변이 이미 있을때 발생 할 수 있는 `AnswerAlreadyExistsException` 을 검증 했습니다.
- `delete` 시 다른 사람의 답변을 삭제할 때 발생할 수 있는 `AccessNotFoundException`을 검증 했습니다.

code coverage 를 다음과같이 달성했습니다.
<img width="781" alt="스크린샷 2021-06-13 15 18 12" src="https://user-images.githubusercontent.com/62932968/121797463-3d737880-cc5b-11eb-93b6-d4707e78b799.png">
