### PR TITLE
Feature/jwt refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
+			<version>1.18.20</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
-			<version>1.18.20</version>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/moment/the/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/moment/the/admin/service/AdminServiceImpl.java
@@ -48,7 +48,7 @@ public class AdminServiceImpl implements AdminService {
         final String accessToken = jwtUtil.generateAccessToken(adminDomain.getAdminId());
         final String refreshJwt = jwtUtil.generateRefreshToken(adminDomain.getAdminId());
         // token 만료 기간 설정
-        redisUtil.setDataExpire(adminDomain.getUsername(), refreshJwt, jwtUtil.REFRESH_TOKEN_EXPIRATION_TIME);
+        redisUtil.setDataExpire(refreshJwt, adminDomain.getUsername(), JwtUtil.REFRESH_TOKEN_EXPIRATION_TIME);
         Map<String ,String> map = new HashMap<>();
         map.put("id", adminDomain.getAdminId());
         map.put("accessToken", accessToken); // accessToken 반환

--- a/src/main/java/com/moment/the/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/moment/the/admin/service/AdminServiceImpl.java
@@ -48,7 +48,7 @@ public class AdminServiceImpl implements AdminService {
         final String accessToken = jwtUtil.generateAccessToken(adminDomain.getAdminId());
         final String refreshJwt = jwtUtil.generateRefreshToken(adminDomain.getAdminId());
         // token 만료 기간 설정
-        redisUtil.setDataExpire(adminDomain.getUsername(), refreshJwt, jwtUtil.REFRESH_TOKEN_VALIDATION_SECOND);
+        redisUtil.setDataExpire(adminDomain.getUsername(), refreshJwt, jwtUtil.REFRESH_TOKEN_EXPIRATION_TIME);
         Map<String ,String> map = new HashMap<>();
         map.put("id", adminDomain.getAdminId());
         map.put("accessToken", accessToken); // accessToken 반환

--- a/src/main/java/com/moment/the/config/mvc/ExceptionHandlerFilter.java
+++ b/src/main/java/com/moment/the/config/mvc/ExceptionHandlerFilter.java
@@ -35,6 +35,7 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
         }catch (UserNotFoundException e){
             setExceptionRes(HttpStatus.BAD_REQUEST, res, exceptionAdvice.userNotFoundException(req, e));
         } catch (Exception e){
+            log.error("알 수 없는 에러 발생", e);
             setExceptionRes(HttpStatus.INTERNAL_SERVER_ERROR, res, exceptionAdvice.defaultException(req, e));
         }
 

--- a/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
@@ -40,7 +40,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
         // accessToken 검사
         try{
-            if(accessJwt != null && jwtUtil.getUserTokenType(accessJwt).equals(JwtUtil.ACCESS_TOKEN_NAME))
+            if(accessJwt != null && jwtUtil.getTokenType(accessJwt).equals(JwtUtil.ACCESS_TOKEN_NAME))
                 userEmail = jwtUtil.getUserEmail(accessJwt);
 
             if(userEmail != null){

--- a/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
@@ -68,7 +68,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
      */
     private String accessTokenExtractEmail(String accessToken) {
         try {
-            if(jwtUtil.getTokenType(accessToken).equals(JwtUtil.TYPE_OF_ACCESS_TOKEN))
+            if(jwtUtil.getTokenType(accessToken).equals(JwtUtil.TokenType.REFRESH_TOKEN.value))
                 return accessToken;
             else
                 return null;
@@ -102,13 +102,14 @@ public class JwtRequestFilter extends OncePerRequestFilter {
     /**
      * @param refreshToken - 유저가 가지고 있는 refreshToken
      * @return newAccessToken - 새로만든 AccessToken을 발급합니다.
+     * @throws InvalidTokenException RefreshToken이 올바르지 않을때 throws된다.
      * @author 정시원
      */
     private String generateNewAccessToken(String refreshToken) {
         try {
             return jwtUtil.generateAccessToken(jwtUtil.getUserEmail(refreshToken));
-        } catch (IllegalArgumentException e) {
-            throw new AccessTokenExpiredException();
+        } catch (IllegalArgumentException | UnsupportedJwtException | SignatureException | MalformedJwtException | ExpiredJwtException e) {
+            throw new InvalidTokenException();
         }
     }
 }

--- a/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
@@ -37,13 +37,8 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
         // accessToken 검사
         if (userEmail != null) {
-            log.debug("jwt userEmail {}", userEmail);
-            try {
-                // 토큰에서 추출한 user email를 통해 유저정보를 찾아 Security Context에 등록한다. 유저정보가 없으면 NullPointerException이 발생한다.
-                registerUserInfoToSecurityContext(userEmail, req);
-            } catch (NullPointerException e) {
-                throw new UserNotFoundException();
-            }
+            log.debug("jwt userEmail = {}", userEmail);
+            registerUserInfoToSecurityContext(userEmail, req);
         }
 
         //accessToken 이 만료되었을때 refreshToken 을 사용하여 accessToken 재발급한다.
@@ -78,8 +73,19 @@ public class JwtRequestFilter extends OncePerRequestFilter {
         }
     }
 
-    private void registerUserInfoToSecurityContext(String userEmail, HttpServletRequest req) throws NullPointerException{
-        UserDetails userDetails = myUserDetailsService.loadUserByUsername(userEmail);
+    /**
+     * user email로 사용자의 유무를 판단해 SecurityContext에 유저를 등록한다.
+     * @param userEmail - String
+     * @param req - HttpServletRequest
+     * @throws UserNotFoundException - 해당 사용자가 없을 경우 throw 된다.
+     */
+    private void registerUserInfoToSecurityContext(String userEmail, HttpServletRequest req){
+        UserDetails userDetails;
+        try{
+            userDetails = myUserDetailsService.loadUserByUsername(userEmail);
+        }catch (NullPointerException e){
+            throw new UserNotFoundException();
+        }
 
         UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
         usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));

--- a/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
@@ -1,7 +1,6 @@
 package com.moment.the.config.security.jwt;
 
 import com.moment.the.config.security.auth.MyUserDetailsService;
-import com.moment.the.exceptionAdvice.exception.AccessTokenExpiredException;
 import com.moment.the.exceptionAdvice.exception.InvalidTokenException;
 import com.moment.the.exceptionAdvice.exception.UserNotFoundException;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -43,7 +42,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
             userEmail = accessTokenExtractEmail(accessToken);
             if(userEmail != null)
-                registerUserInfoToSecurityContext(userEmail, req);
+                registerUserInfoInSecurityContext(userEmail, req);
 
             // Access Token이 만료되고 Refresh Token이 존재해야지 새로운 AccessToken을 반한한다.
             if(jwtUtil.isTokenExpired(accessToken) && refreshToken != null){
@@ -87,7 +86,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
      * @throws UserNotFoundException - 해당 사용자가 없을 경우 throw 된다.
      * @author 정시원
      */
-    private void registerUserInfoToSecurityContext(String userEmail, HttpServletRequest req) {
+    private void registerUserInfoInSecurityContext(String userEmail, HttpServletRequest req) {
         try {
             UserDetails userDetails = myUserDetailsService.loadUserByUsername(userEmail);
 

--- a/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
@@ -58,7 +58,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
     /**
      * accessToken에서 userEmail claim 값을 추출한다.
-     * @param accessToken
+     * @param accessToken Access Token
      * @return userEmail - accessToken에서 정상적으로 email를 추출할때 user email을 반한한다.
      * @throws InvalidTokenException - accessToken이 null이 아니고 올바르지 않을때 발생한다.
      * @author 정시원

--- a/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
@@ -46,7 +46,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
                 registerUserInfoToSecurityContext(userEmail, req);
 
             // Access Token이 만료되고 Refresh Token이 존재해야지 새로운 AccessToken을 반한한다.
-            if(jwtUtil.isTokenExpired(accessToken)  || refreshToken != null){
+            if(jwtUtil.isTokenExpired(accessToken) && refreshToken != null){
                 log.debug("=== AccessToken 만료 ===");
 
                 String newAccessToken = generateNewAccessToken(refreshToken);
@@ -55,7 +55,6 @@ public class JwtRequestFilter extends OncePerRequestFilter {
                 log.debug("=== AccessToken 발급 ===");
             }
         }
-
         filterChain.doFilter(req, res);
     }
 
@@ -69,7 +68,10 @@ public class JwtRequestFilter extends OncePerRequestFilter {
      */
     private String accessTokenExtractEmail(String accessToken) {
         try {
-            return jwtUtil.getUserEmail(accessToken);
+            if(jwtUtil.getTokenType(accessToken).equals(JwtUtil.TYPE_OF_ACCESS_TOKEN))
+                return accessToken;
+            else
+                return null;
         } catch (IllegalArgumentException | ExpiredJwtException e) {
             return null;
         } catch (MalformedJwtException | UnsupportedJwtException | SignatureException e ) {

--- a/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
@@ -1,11 +1,9 @@
 package com.moment.the.config.security.jwt;
 
 import com.moment.the.config.security.auth.MyUserDetailsService;
-import com.moment.the.exceptionAdvice.exception.AccessTokenExpiredException;
 import com.moment.the.exceptionAdvice.exception.InvalidTokenException;
 import com.moment.the.exceptionAdvice.exception.UserNotFoundException;
 import com.moment.the.util.RedisUtil;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,48 +33,47 @@ public class JwtRequestFilter extends OncePerRequestFilter {
         String accessJwt = req.getHeader("Authorization");
         String refreshJwt = req.getHeader("RefreshToken");
 
-        String userEmail = null;
-        String refreshEmail = null;
+        String userEmail = accessJwt != null ? jwtUtil.getUserEmail(accessJwt) : null;
 
         // accessToken 검사
-        try{
-            if(accessJwt != null && jwtUtil.getTokenType(accessJwt).equals(JwtUtil.ACCESS_TOKEN_NAME))
-                userEmail = jwtUtil.getUserEmail(accessJwt);
+        try {
+            if (accessJwt != null && jwtUtil.validateToken(accessJwt, JwtUtil.ACCESS_TOKEN_NAME)) {
+                if (userEmail != null) {
+                    log.debug("jwt userEmail {}", userEmail);
 
-            if(userEmail != null){
-                System.out.println("jwt userEmail " + userEmail);
-                UserDetails userDetails = myUserDetailsService.loadUserByUsername(userEmail);
+                    //토큰 발급후 유저 정보 확인
+                    try {
 
-                //토큰 발급후 유저 정보 확인
-                try{
-
-                    if(jwtUtil.validateToken(accessJwt, userDetails)){
-                        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(userDetails,null,userDetails.getAuthorities());
-                        usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
-                        SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+                    } catch (NullPointerException e) {
+                        throw new UserNotFoundException();
                     }
+                }
+            }
 
-                }catch (NullPointerException e){
-                    throw new UserNotFoundException();
-                }
-            }
-        //accessToken 이 만료되었을때 refreshToken 을 사용하여 accessToken 재발급한다.
-        }catch (ExpiredJwtException e){
-            if(refreshJwt != null){
-                refreshEmail = jwtUtil.getUserEmail(refreshJwt);
-                if(refreshJwt.equals(redisUtil.getData(refreshEmail))){
-                    String newJwt = jwtUtil.generateAccessToken(refreshEmail);
-                    res.addHeader("JwtToken", newJwt);
-                }
-            }else{
-                throw new AccessTokenExpiredException();
-            }
+            //accessToken 이 만료되었을때 refreshToken 을 사용하여 accessToken 재발급한다.
+//        }catch (ExpiredJwtException e){
+//            if(refreshJwt != null){
+//                refreshEmail = jwtUtil.getUserEmail(refreshJwt);
+//                if(refreshJwt.equals(redisUtil.getData(refreshEmail))){
+//                    String newJwt = jwtUtil.generateAccessToken(refreshEmail);
+//                    res.addHeader("JwtToken", newJwt);
+//                }
+//            }else{
+//                throw new AccessTokenExpiredException();
+//            }
         } catch(MalformedJwtException e){
             throw new InvalidTokenException();
-        } catch(IllegalArgumentException e){ //헤더에 토큰이 없으면 NPE 발생 하여 추가하였다. 추가적인 의미는 없다.
-        }
+        } catch(IllegalArgumentException e){} //헤더에 토큰이 없으면 NPE 발생 하여 추가하였다. 추가적인 의미는 없다.
 
         filterChain.doFilter(req,res); //필터 체인을 따라 계속 다음에 존재하는 필터로 이동한다.
 
+    }
+
+    private void registerUserInfoInSecurityContext(String userEmail, HttpServletRequest req){
+        UserDetails userDetails = myUserDetailsService.loadUserByUsername(userEmail);
+
+        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
+        SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
     }
 }

--- a/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
@@ -6,7 +6,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
@@ -21,11 +20,11 @@ public class JwtUtil {
     public final static long ACCESS_TOKEN_EXPIRATION_TIME = 1000l * 3600 * 6;  // milli_sec * hour * 6 = 6hour
     public final static long REFRESH_TOKEN_EXPIRATION_TIME = 1000l * 3600 * 24 * 30 * 7;  // milli_sec X hour X day X month * 7 = 7month
 
-    final static public String ACCESS_TOKEN_NAME = "accessToken";
-    final static public String REFRESH_TOKEN_NAME = "refreshToken";
+    final static public String TYPE_OF_ACCESS_TOKEN = "accessToken";
+    final static public String TYPE_OF_REFRESH_TOKEN = "refreshToken";
 
-    final static public String TOKEN_CLAIM_NAME_USER_EMAIL = "userEmail"; // token의 user email 추출시 필요한 claims이름
-    final static public String TOKEN_CLAIM_NAME_TOKEN_TYPE = "tokenType";
+    final static public String TOKEN_CLAIM_NAME_FOR_USER_EMAIL = "userEmail"; // token의 user email 추출시 필요한 claims이름
+    final static public String TOKEN_CLAIM_NAME_FOR_TOKEN_TYPE = "tokenType";
 
     private Key getSigningKey(String secretKey) {
         byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
@@ -41,50 +40,44 @@ public class JwtUtil {
     }
 
     public String getUserEmail(String token){
-        return extractAllClaims(token).get(TOKEN_CLAIM_NAME_USER_EMAIL, String.class);
+        return extractAllClaims(token).get(TOKEN_CLAIM_NAME_FOR_USER_EMAIL, String.class);
     }
 
     public String getTokenType(String token){
-        return extractAllClaims(token).get(TOKEN_CLAIM_NAME_TOKEN_TYPE, String.class);
+        return extractAllClaims(token).get(TOKEN_CLAIM_NAME_FOR_TOKEN_TYPE, String.class);
     }
 
     public Boolean isTokenExpired(String token) {
-        final Date expiration = extractAllClaims(token).getExpiration();
-        return expiration.before(new Date());
+        try{
+            extractAllClaims(token).getExpiration();
+            return false;
+        }catch(ExpiredJwtException e){
+            return true;
+        }
     }
 
-    public String generateAccessToken(String email) {
-        return doGenerateToken(email, ACCESS_TOKEN_NAME, ACCESS_TOKEN_EXPIRATION_TIME);
-    }
-
-    public String generateRefreshToken(String email) {
-        return doGenerateToken(email, REFRESH_TOKEN_NAME, REFRESH_TOKEN_EXPIRATION_TIME);
+    public Boolean validateToken(final String token, final String tokenType) {
+        return !isTokenExpired(token) && getTokenType(token).equals(tokenType);
     }
 
     public String doGenerateToken(String userEmail, String tokenType, long expireTime) {
         final Claims claims = Jwts.claims();
         claims.put("userEmail", userEmail);
         claims.put("tokenType", tokenType);
-        String jwt = Jwts.builder()
+        return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + expireTime))
                 .signWith(getSigningKey(SECRET_KEY), SignatureAlgorithm.HS256)
                 .compact();
-        return jwt;
     }
 
-    public Boolean validateGeneralToken(String token){
-        try{
-            extractAllClaims(token);
-        }catch (ExpiredJwtException e){
-            return false;
-        }
-        return !isTokenExpired(token);
+    public String generateAccessToken(String email) {
+        return doGenerateToken(email, TYPE_OF_ACCESS_TOKEN, ACCESS_TOKEN_EXPIRATION_TIME);
     }
 
-    public Boolean validateAccessToken(String token, UserDetails userDetails) {
-        final String username = getUserEmail(token);
-        return username.equals(userDetails.getUsername()) && !isTokenExpired(token) && getTokenType(token).equals(ACCESS_TOKEN_NAME);
+    public String generateRefreshToken(String email) {
+        return doGenerateToken(email, TYPE_OF_REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_TIME);
     }
+
 }

--- a/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
@@ -18,12 +18,8 @@ public class JwtUtil {
     @Value("${spring.jwt.secret}")
     private String SECRET_KEY;
 
-
-    public final static long MILLI_SEC = 1000l; // 1밀리초
-    public final static long HOUR = 3600;   //1시간
-
-    public final static long TOKEN_VALIDATION_SECOND = MILLI_SEC * HOUR * 6;  //6시간을 accessToken 만료 기간으로 잡는다
-    public final static long REFRESH_TOKEN_VALIDATION_SECOND = MILLI_SEC * HOUR * 24 * 210; //7개월을 refreshToken 만료 기간으로 잡는다.
+    public final static long TOKEN_VALIDATION_SECOND = 1000l * 3600 * 6;  // milli_sec * hour * 6 = 6hour
+    public final static long REFRESH_TOKEN_VALIDATION_SECOND = 1000l * 3600 * 24 * 30 * 7;  // milli_sec X hour X day X month * 7 = 7month
 
     final static public String ACCESS_TOKEN_NAME = "accessToken";
     final static public String REFRESH_TOKEN_NAME = "refreshToken";

--- a/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
@@ -18,8 +18,13 @@ public class JwtUtil {
     public final static long ACCESS_TOKEN_EXPIRATION_TIME = 1000l * 3600 * 6;  // milli_sec * hour * 6 = 6hour
     public final static long REFRESH_TOKEN_EXPIRATION_TIME = 1000l * 3600 * 24 * 30 * 7;  // milli_sec X hour X day X month * 7 = 7month
 
-    final static public String TYPE_OF_ACCESS_TOKEN = "accessToken";
-    final static public String TYPE_OF_REFRESH_TOKEN = "refreshToken";
+    enum TokenType{
+        ACCESS_TOKEN("accessToken"),
+        REFRESH_TOKEN("refreshToken");
+        String value;
+
+        TokenType(String value) { this.value = value; }
+    }
 
     final static public String TOKEN_CLAIM_NAME_FOR_USER_EMAIL = "userEmail"; // token의 user email 추출시 필요한 claims이름
     final static public String TOKEN_CLAIM_NAME_FOR_TOKEN_TYPE = "tokenType";
@@ -65,10 +70,10 @@ public class JwtUtil {
         }
     }
 
-    public String doGenerateToken(String userEmail, String tokenType, long expireTime) {
+    public String doGenerateToken(String userEmail, TokenType tokenType, long expireTime) {
         final Claims claims = Jwts.claims();
         claims.put("userEmail", userEmail);
-        claims.put("tokenType", tokenType);
+        claims.put("tokenType", tokenType.value);
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
@@ -78,11 +83,11 @@ public class JwtUtil {
     }
 
     public String generateAccessToken(String email) {
-        return doGenerateToken(email, TYPE_OF_ACCESS_TOKEN, ACCESS_TOKEN_EXPIRATION_TIME);
+        return doGenerateToken(email, TokenType.ACCESS_TOKEN, ACCESS_TOKEN_EXPIRATION_TIME);
     }
 
     public String generateRefreshToken(String email) {
-        return doGenerateToken(email, TYPE_OF_REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_TIME);
+        return doGenerateToken(email, TokenType.REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_TIME);
     }
 
 }

--- a/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
@@ -65,10 +65,6 @@ public class JwtUtil {
         }
     }
 
-    public Boolean validateToken(final String token, final String tokenType) {
-        return !isTokenExpired(token) && getTokenType(token).equals(tokenType);
-    }
-
     public String doGenerateToken(String userEmail, String tokenType, long expireTime) {
         final Claims claims = Jwts.claims();
         claims.put("userEmail", userEmail);

--- a/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
@@ -1,10 +1,8 @@
 package com.moment.the.config.security.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -31,7 +29,18 @@ public class JwtUtil {
         return Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public Claims extractAllClaims(String token) throws ExpiredJwtException {
+    /**
+     * JWT에서 claims 추출하는 함수
+     * @param token JWT
+     * @return Jwts - JwtToken의 Claims 값을 모두 추출한 Jwts객체
+     * @throws ExpiredJwtException - JWT를 생성할 떄 지정한 유효기간을 초과할 때 발생힌다.
+     * @throws IllegalArgumentException - JWT이 비어있을때 발생한다.
+     * @throws MalformedJwtException - JWT가 올바르게 구성되지 않았을 떄 발생한다.
+     * @throws SignatureException - JWT의 기존 서명을 확인하지 못했을 때
+     * @throws UnsupportedJwtException 예상하는 형식과 일치하지 않는 특정 형식이나 구성의 JWT일 때
+     * @author 정시원
+     */
+    public Claims extractAllClaims(String token) throws ExpiredJwtException, IllegalArgumentException, MalformedJwtException, SignatureException, UnsupportedJwtException {
         return Jwts.parserBuilder()
                 .setSigningKey(getSigningKey(SECRET_KEY))
                 .build()
@@ -51,7 +60,7 @@ public class JwtUtil {
         try{
             extractAllClaims(token).getExpiration();
             return false;
-        }catch(ExpiredJwtException e){
+        }catch(ExpiredJwtException e) {
             return true;
         }
     }

--- a/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
@@ -15,8 +15,8 @@ public class JwtUtil {
     @Value("${spring.jwt.secret}")
     private String SECRET_KEY;
     
-    public final static long ACCESS_TOKEN_EXPIRATION_TIME = 1000l * 3600 * 6;  // milli_sec * hour * 6 = 6hour
-    public final static long REFRESH_TOKEN_EXPIRATION_TIME = 1000l * 3600 * 24 * 30 * 7;  // milli_sec X hour X day X month * 7 = 7month
+    public final static long ACCESS_TOKEN_EXPIRATION_TIME = 1000L * 3600 * 6;  // milli_sec * hour * 6 = 6hour
+    public final static long REFRESH_TOKEN_EXPIRATION_TIME = 1000L * 3600 * 24 * 30 * 7;  // milli_sec X hour X day X month * 7 = 7month
 
     enum TokenType{
         ACCESS_TOKEN("accessToken"),

--- a/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
@@ -17,9 +17,9 @@ import java.util.Date;
 public class JwtUtil {
     @Value("${spring.jwt.secret}")
     private String SECRET_KEY;
-
-    public final static long TOKEN_VALIDATION_SECOND = 1000l * 3600 * 6;  // milli_sec * hour * 6 = 6hour
-    public final static long REFRESH_TOKEN_VALIDATION_SECOND = 1000l * 3600 * 24 * 30 * 7;  // milli_sec X hour X day X month * 7 = 7month
+    
+    public final static long ACCESS_TOKEN_EXPIRATION_TIME = 1000l * 3600 * 6;  // milli_sec * hour * 6 = 6hour
+    public final static long REFRESH_TOKEN_EXPIRATION_TIME = 1000l * 3600 * 24 * 30 * 7;  // milli_sec X hour X day X month * 7 = 7month
 
     final static public String ACCESS_TOKEN_NAME = "accessToken";
     final static public String REFRESH_TOKEN_NAME = "refreshToken";
@@ -40,7 +40,8 @@ public class JwtUtil {
     public String getUserEmail(String token){
         return extractAllClaims(token).get("userEmail", String.class);
     }
-    public String getUserTokenType(String token){
+
+    public String getTokenType(String token){
         return extractAllClaims(token).get("tokenType", String.class);
     }
 
@@ -50,16 +51,15 @@ public class JwtUtil {
     }
 
     public String generateAccessToken(String email) {
-        return doGenerateToken(email, ACCESS_TOKEN_NAME, TOKEN_VALIDATION_SECOND);
+        return doGenerateToken(email, ACCESS_TOKEN_NAME, ACCESS_TOKEN_EXPIRATION_TIME);
     }
 
     public String generateRefreshToken(String email) {
-        return doGenerateToken(email, REFRESH_TOKEN_NAME, REFRESH_TOKEN_VALIDATION_SECOND);
+        return doGenerateToken(email, REFRESH_TOKEN_NAME, REFRESH_TOKEN_EXPIRATION_TIME);
     }
 
     public String doGenerateToken(String userEmail, String tokenType, long expireTime) {
-
-        Claims claims = Jwts.claims();
+        final Claims claims = Jwts.claims();
         claims.put("userEmail", userEmail);
         claims.put("tokenType", tokenType);
         String jwt = Jwts.builder()
@@ -73,6 +73,6 @@ public class JwtUtil {
 
     public Boolean validateToken(String token, UserDetails userDetails) {
         final String username = getUserEmail(token);
-        return username.equals(userDetails.getUsername()) && !isTokenExpired(token) && getUserTokenType(token).equals(ACCESS_TOKEN_NAME);
+        return username.equals(userDetails.getUsername()) && !isTokenExpired(token) && getTokenType(token).equals(ACCESS_TOKEN_NAME);
     }
 }

--- a/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
@@ -24,6 +24,9 @@ public class JwtUtil {
     final static public String ACCESS_TOKEN_NAME = "accessToken";
     final static public String REFRESH_TOKEN_NAME = "refreshToken";
 
+    final static public String TOKEN_CLAIM_NAME_USER_EMAIL = "userEmail"; // token의 user email 추출시 필요한 claims이름
+    final static public String TOKEN_CLAIM_NAME_TOKEN_TYPE = "tokenType";
+
     private Key getSigningKey(String secretKey) {
         byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
         return Keys.hmacShaKeyFor(keyBytes);
@@ -38,11 +41,11 @@ public class JwtUtil {
     }
 
     public String getUserEmail(String token){
-        return extractAllClaims(token).get("userEmail", String.class);
+        return extractAllClaims(token).get(TOKEN_CLAIM_NAME_USER_EMAIL, String.class);
     }
 
     public String getTokenType(String token){
-        return extractAllClaims(token).get("tokenType", String.class);
+        return extractAllClaims(token).get(TOKEN_CLAIM_NAME_TOKEN_TYPE, String.class);
     }
 
     public Boolean isTokenExpired(String token) {
@@ -71,7 +74,16 @@ public class JwtUtil {
         return jwt;
     }
 
-    public Boolean validateToken(String token, UserDetails userDetails) {
+    public Boolean validateGeneralToken(String token){
+        try{
+            extractAllClaims(token);
+        }catch (ExpiredJwtException e){
+            return false;
+        }
+        return !isTokenExpired(token);
+    }
+
+    public Boolean validateAccessToken(String token, UserDetails userDetails) {
         final String username = getUserEmail(token);
         return username.equals(userDetails.getUsername()) && !isTokenExpired(token) && getTokenType(token).equals(ACCESS_TOKEN_NAME);
     }

--- a/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
@@ -26,8 +26,13 @@ public class JwtUtil {
         TokenType(String value) { this.value = value; }
     }
 
-    final static public String TOKEN_CLAIM_NAME_FOR_USER_EMAIL = "userEmail"; // token의 user email 추출시 필요한 claims이름
-    final static public String TOKEN_CLAIM_NAME_FOR_TOKEN_TYPE = "tokenType";
+    enum TokenClaimName{
+        USER_EMAIL("userEmail"),
+        TOKEN_TYPE("tokenType");
+        String value;
+
+        TokenClaimName(String value) { this.value = value; }
+    }
 
     private Key getSigningKey(String secretKey) {
         byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
@@ -54,11 +59,11 @@ public class JwtUtil {
     }
 
     public String getUserEmail(String token){
-        return extractAllClaims(token).get(TOKEN_CLAIM_NAME_FOR_USER_EMAIL, String.class);
+        return extractAllClaims(token).get(TokenClaimName.USER_EMAIL.value, String.class);
     }
 
     public String getTokenType(String token){
-        return extractAllClaims(token).get(TOKEN_CLAIM_NAME_FOR_TOKEN_TYPE, String.class);
+        return extractAllClaims(token).get(TokenClaimName.TOKEN_TYPE.value, String.class);
     }
 
     public Boolean isTokenExpired(String token) {

--- a/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
@@ -34,6 +34,11 @@ public class JwtUtil {
         TokenClaimName(String value) { this.value = value; }
     }
 
+    /**
+     * JWT에 넣을 비밀키를 인코딩하여 반환한다.
+     * @param secretKey 비밀키
+     * @return secretKey
+     */
     private Key getSigningKey(String secretKey) {
         byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
         return Keys.hmacShaKeyFor(keyBytes);
@@ -58,14 +63,32 @@ public class JwtUtil {
                 .getBody();
     }
 
+    /**
+     * 토큰의 userEmail claim에서 email를 추출한다.
+     * @param token JWT
+     * @return String email
+     * @author 정시원
+     */
     public String getUserEmail(String token){
         return extractAllClaims(token).get(TokenClaimName.USER_EMAIL.value, String.class);
     }
 
+    /**
+     * 토큰의 tokenType claim에서 token type을 추출한다.
+     * @param token JWT
+     * @return String tokenType
+     * @author 정시원
+     */
     public String getTokenType(String token){
         return extractAllClaims(token).get(TokenClaimName.TOKEN_TYPE.value, String.class);
     }
 
+    /**
+     * 토큰이 만료여부에 따라 true/false를 반환한다.
+     * @param token JWT
+     * @return true - 토큰이 만료되었을 때
+     * @author 정시원
+     */
     public Boolean isTokenExpired(String token) {
         try{
             extractAllClaims(token).getExpiration();
@@ -75,7 +98,15 @@ public class JwtUtil {
         }
     }
 
-    public String doGenerateToken(String userEmail, TokenType tokenType, long expireTime) {
+    /**
+     * JWT를 만든다.
+     * @param userEmail JWT에 넣을 userEmail claim값
+     * @param tokenType AccessToken, RefreshToken 구분
+     * @param expireTime 만료시간
+     * @return JWT
+     * @author 정시원
+     */
+    private String doGenerateToken(String userEmail, TokenType tokenType, long expireTime) {
         final Claims claims = Jwts.claims();
         claims.put("userEmail", userEmail);
         claims.put("tokenType", tokenType.value);
@@ -87,10 +118,22 @@ public class JwtUtil {
                 .compact();
     }
 
+    /**
+     * AccessToken을 만든다.
+     * @param email 현재 사용자의 사용자의 email
+     * @return AccessToken
+     * @author 정시원
+     */
     public String generateAccessToken(String email) {
         return doGenerateToken(email, TokenType.ACCESS_TOKEN, ACCESS_TOKEN_EXPIRATION_TIME);
     }
 
+    /**
+     * RefreshToken을 만든다.
+     * @param email 현재 사용자의 email
+     * @return RefreshToken
+     * @author 정시원
+     */
     public String generateRefreshToken(String email) {
         return doGenerateToken(email, TokenType.REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_TIME);
     }

--- a/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtUtil.java
@@ -108,7 +108,9 @@ public class JwtUtil {
      */
     private String doGenerateToken(String userEmail, TokenType tokenType, long expireTime) {
         final Claims claims = Jwts.claims();
-        claims.put("userEmail", userEmail);
+        //AccessToken일 떄 TokenClaim에 UserEmail을 추가한다.
+        if(TokenType.ACCESS_TOKEN == tokenType)
+            claims.put("userEmail", userEmail);
         claims.put("tokenType", tokenType.value);
         return Jwts.builder()
                 .setClaims(claims)


### PR DESCRIPTION
코드 리펙토링에서 심각한 오류들이 많이 발견되어서 수정이 많이 일어날 거 같아요 그래서 중간 리뷰 부탁드려요

### 한 일
1. `JwtRequestFIlter` 리펙토링
2. `RefreshToken`검증 방식을 변경했습니다.   
    **before** 
     `RefreshToken`이 유효하면 `RefreshToken`의 클레임에서 `UserEmail`을 추출한 후 그`UserEmail`로 `Redis`에서 `RefreshToken`을 찾아 사용자가 보낸 `RefreshToken`과 `Redis`에서 찾은 `RefreshToken`을 검증했습니다. 
    
    **after**   
    `RefreshToken`을 통해 `Redis`에서 `UserEmail`을 찾아옵니다. 그`UserEmail`로 새로운 `AccessToken`을 생성합니다.  
     > 앞으로 reids에 다음과 같이 저장됩니다. `RefreshToken`이 key값, `UserEmail`이 value 값이 되었습니다.  
     > (`AdminServiceImpl` 51 번째줄)

### 앞으로 변경할 예정
- `JwtUtil` Jwt 검증 method들을 다시 로직을 짜야 될 거 같아요 `Jwts`객체의 이해도가 떨어진 코드들이 있어 논리적으로 코드가 올바르게 동작하지 않습니다.
   > JWT검증은 `Jwts`객체에서 `getBody()`를 하면 이미 검증된 상태로 Claim을 추출할 수 있어요, 토큰이 만료되거나, 올바르지 않으면 `Exception`을 발생시킵니다. 즉 저희는 검증 매서드(`validateToken`, `isTokenExpired`등...)에서 예외처리를 해야 되는데 검증된 값을 또 검증하고 있던 꼴이죠..
- 인증로직에 대한 테스트 코드 작성

### 코드리뷰 원해요
- 메서드 변수 네이밍
- 논리적인 오류 및 모호한 부분 지적
- 더 나은 알고리즘 있을 시 피드백