### PR TITLE
[Update] Readme 오타 수정및 실행 명령어 주석처리

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <br>
 
-#### Installing Services - Ubunutu
+#### Installing Services - Ubuntu
 ```bash
 #!/bin/bash
 
@@ -26,7 +26,7 @@ sudo apt-get install openjdk-11-jdk -y
 # move to server directory ex) ~/the-moment-server
 
 # start the_moment-server use shell! (Docker Run)
-sudo ./docker-compose-env.sh
+# sudo ./docker-compose-env.sh
 
 # Run in the background as well (prefer)
 sudo nohup ./docker-compose-env.sh &


### PR DESCRIPTION
### 오타 수정
Ubunutu -> Ubuntu
### 명령어 주석처리
`sudo ./docker-compose-env.sh` -> 백그라운드 실행을 하지 않기 떄문에 `sudo nohup ./docker-compose-env.sh &` 하나만 실행 시킬수 있도록 주석처리 해줌.